### PR TITLE
001 signup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### API KEY properties ###
+application-apikey.properties
+application-db.properties

--- a/build.gradle
+++ b/build.gradle
@@ -22,15 +22,24 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+    implementation "io.jsonwebtoken:jjwt-root:0.11.5" // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // jpa
+    implementation 'org.springframework.boot:spring-boot-starter-security' // spring-security
+    implementation 'org.springframework.boot:spring-boot-starter-web' // spring-web
+
+    compileOnly 'org.projectlombok:lombok' // lombok
+
+    runtimeOnly 'com.h2database:h2' // h2(혹시몰라서)
+    runtimeOnly 'com.mysql:mysql-connector-j' // mysql
+
+    annotationProcessor 'org.projectlombok:lombok' // lombok
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test' // spring-web
+    testImplementation 'org.springframework.security:spring-security-test' // spring-security
 }
 
 tasks.named('test') {

--- a/src/main/java/com/zerobase/commerce/CartItem.java
+++ b/src/main/java/com/zerobase/commerce/CartItem.java
@@ -1,0 +1,27 @@
+package com.zerobase.commerce;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CartItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "productId", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private Long quantity;
+}

--- a/src/main/java/com/zerobase/commerce/CommerceApplication.java
+++ b/src/main/java/com/zerobase/commerce/CommerceApplication.java
@@ -2,8 +2,10 @@ package com.zerobase.commerce;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CommerceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/zerobase/commerce/Product.java
+++ b/src/main/java/com/zerobase/commerce/Product.java
@@ -1,0 +1,31 @@
+package com.zerobase.commerce;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Long price;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private Long averageRating;
+
+    @Column(nullable = false)
+    private Long reviewCount;
+}

--- a/src/main/java/com/zerobase/commerce/Review.java
+++ b/src/main/java/com/zerobase/commerce/Review.java
@@ -1,0 +1,31 @@
+package com.zerobase.commerce;
+
+import com.zerobase.commerce.user.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Review extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "productId", nullable = false)
+    private Product product;
+
+    @Column
+    private Double rating;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+}

--- a/src/main/java/com/zerobase/commerce/Role.java
+++ b/src/main/java/com/zerobase/commerce/Role.java
@@ -1,0 +1,12 @@
+package com.zerobase.commerce;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Role {
+    USER,
+    SELLER,
+    ADMIN
+}

--- a/src/main/java/com/zerobase/commerce/User.java
+++ b/src/main/java/com/zerobase/commerce/User.java
@@ -1,0 +1,27 @@
+package com.zerobase.commerce;
+
+import com.zerobase.commerce.user.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 45, unique = true)
+    private String userId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String username;
+
+}

--- a/src/main/java/com/zerobase/commerce/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/commerce/configuration/SecurityConfiguration.java
@@ -1,0 +1,95 @@
+package com.zerobase.commerce.configuration;
+
+import com.zerobase.commerce.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static com.zerobase.commerce.Role.ADMIN;
+import static com.zerobase.commerce.Role.USER;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfiguration {
+
+    // BCryptPasswordEncoder를 통해서 비밀번호를 암호화하고 해당 빈을 통해서 암호화 및 비교작업 수행
+    @Bean
+    PasswordEncoder getPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // UserAuthenticationFailureHandler를 빈으로 등록하는 메서드이다.
+    // 이 핸들러는 사용자의 로그인 실패 시에 호출되는 동작을 정의하는 것으로
+    // 로그인 실패에 대한 추가적인 로직이 필요한 경우에 사용하는 것이다.
+    @Bean
+    UserAuthenticationFailureHandler getFailureHandler() {
+        return new UserAuthenticationFailureHandler();
+    }
+
+    // 이렇게 하면 auth.userDetailsService(memberService).passwordEncoder(getPasswordEncoder());
+    // 이거 적용한 거랑 같은 효과가 나온다는것 같은데 왜 그런지는 모르겠음..
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    protected SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // http.csrf().disable()은 deprecated 되었다. 이렇게 메서드 체이닝 쓰지말고 함수형으로 잘 수납해서 쓰라는 것 같다.
+        // (이전에도 지원하는 방식이었지만 사람들이 잘 안 썼다고 한다.)
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // h2로 확인하려고 만든것임
+        http.headers(AbstractHttpConfigurer::disable);
+
+        // jwt를 사용할 것이므로 세션을 stateless, 즉, 서버는 세션을 생성하지 않고, 모든 요청은 세션에 의존하지 않게 만든다.
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        // 여러 접근 제어(프론트 페이지 구현해야 의미있는 부분인듯?)
+        http.authorizeHttpRequests((auth) ->
+                auth
+                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/h2/**").permitAll()
+                        .requestMatchers("/user/signup").permitAll()
+                        .requestMatchers("/user/login").permitAll()
+                        .requestMatchers("/user").hasAnyAuthority(USER.name(), ADMIN.name())
+                        .requestMatchers("/admin/**").hasAuthority(ADMIN.name())
+        );
+
+        // 프론트엔드 페이지 구현시 사용
+//        // 로그인 페이지 엔드포인트 설정
+//        http.formLogin((login) ->
+//                login
+//                        .loginPage("/user/login")
+//                        .failureHandler(getFailureHandler())
+////                        .failureUrl("/user/login?error") // 로그인 실패 시 이동할 URL을 지정합니다.
+//                        .permitAll()
+//        );
+//
+//        // 로그아웃시 루트로 이동
+//        http.logout((logout) ->
+//                logout
+//                        .logoutRequestMatcher(new AntPathRequestMatcher("/"))
+//                        .logoutSuccessUrl("/")
+//                        .permitAll()
+//        );
+//
+//        // 접근한게 권한이 부족하다면 이쪽으로 넘긴다.
+//        http.exceptionHandling((ex) ->
+//                        ex.accessDeniedPage("/user/login"));
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/zerobase/commerce/configuration/TokenProvider.java
+++ b/src/main/java/com/zerobase/commerce/configuration/TokenProvider.java
@@ -1,0 +1,63 @@
+package com.zerobase.commerce.configuration;
+
+import com.zerobase.commerce.user.service.UserService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+    private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7 days
+    private static final long TOKEN_EXPIRE_TIME_TEST1 = 10000; // 10 seconds
+    private static final long TOKEN_EXPIRE_TIME_TEST2 = 1000 * 60 * 60; // 1 hour
+
+    private final UserService userService;
+
+    private Key key = Keys.secretKeyFor(SignatureAlgorithm.HS512);
+
+    /**
+     * 토큰 생성(발급)
+     *
+     * @param userId
+     * @return
+     */
+    public String generateToken(String userId, String role) {
+
+        Claims claims = Jwts.claims().setId(userId); // payload에 담을 값(토큰에 담을 정보를 key-value 형태로 저장한다.)
+        claims.put("role", role);
+
+        var now = new Date();
+        var expiredDate = new Date(now.getTime() + TOKEN_EXPIRE_TIME_TEST2);
+
+        return Jwts.builder()
+                .setHeaderParam("type", "jwt")
+                .setClaims(claims)
+                .setIssuedAt(now) // 토큰 생성 시간
+                .setExpiration(expiredDate) // 토큰 만료 시간
+                .signWith(key) // 사용할 암호화 알고리즘
+                .compact();
+    }
+
+    /**
+     * 토큰 파싱
+     *
+     * @param token
+     * @return
+     */
+    public Jws<Claims> parseToken(String token) {
+        Jws<Claims> claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+
+        return claims;
+    }
+}

--- a/src/main/java/com/zerobase/commerce/configuration/UserAuthenticationFailureHandler.java
+++ b/src/main/java/com/zerobase/commerce/configuration/UserAuthenticationFailureHandler.java
@@ -1,0 +1,33 @@
+package com.zerobase.commerce.configuration;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class UserAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    // 로그인 인증이 실패했을 때 호출되는 메서드이다. 이 메서드를 재정의하여 실패 처리 로직을 구현할 수 있다.
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+
+        // 실패 메시지 설정: exception 객체를 통해 발생한 예외에 따라 실패 메시지를 결정한다.
+        String msg = "로그인에 실패하였습니다.";
+
+        // 만약 InternalAuthenticationServiceException 예외가 발생했다면 해당 예외에서 보내오는 메시지를 사용한다.
+        if (exception instanceof InternalAuthenticationServiceException) {
+            msg = exception.getMessage();
+        }
+
+        setUseForward(true);
+        setDefaultFailureUrl("/errorc");
+
+        request.setAttribute("errorMessage", msg);
+//        getRedirectStrategy().sendRedirect(request, response, "/user/login?error=로그인에 실패하였습니다.");
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/src/main/java/com/zerobase/commerce/user/controller/UserController.java
+++ b/src/main/java/com/zerobase/commerce/user/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.zerobase.commerce.user.controller;
+
+import com.zerobase.commerce.user.dto.form.SignUpForm;
+import com.zerobase.commerce.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/user")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signUpUser(@RequestBody SignUpForm form) {
+        return ResponseEntity.ok(userService.signUp(form));
+    }
+}

--- a/src/main/java/com/zerobase/commerce/user/dto/form/SignUpForm.java
+++ b/src/main/java/com/zerobase/commerce/user/dto/form/SignUpForm.java
@@ -1,0 +1,24 @@
+package com.zerobase.commerce.user.dto.form;
+
+import com.zerobase.commerce.User;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@AllArgsConstructor
+public class SignUpForm {
+    private String userId;
+    private String password;
+    private String checkedPassword;
+    private String username;
+
+    public static User toEntity(SignUpForm form) {
+        return User.builder()
+                .userId(form.getUserId())
+                .password(form.getPassword())
+                .username(form.getUsername())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/commerce/user/entity/BaseTimeEntity.java
+++ b/src/main/java/com/zerobase/commerce/user/entity/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.zerobase.commerce.user.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/zerobase/commerce/user/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/commerce/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.commerce.user.repository;
+
+import com.zerobase.commerce.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUserId(String userId);
+}

--- a/src/main/java/com/zerobase/commerce/user/service/UserService.java
+++ b/src/main/java/com/zerobase/commerce/user/service/UserService.java
@@ -1,0 +1,13 @@
+package com.zerobase.commerce.user.service;
+
+import com.zerobase.commerce.user.dto.form.SignUpForm;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+public interface UserService extends UserDetailsService {
+
+    /**
+     * 회원가입
+     */
+    String signUp(SignUpForm form);
+
+}

--- a/src/main/java/com/zerobase/commerce/user/service/UserServiceImpl.java
+++ b/src/main/java/com/zerobase/commerce/user/service/UserServiceImpl.java
@@ -1,0 +1,65 @@
+package com.zerobase.commerce.user.service;
+
+import com.zerobase.commerce.Role;
+import com.zerobase.commerce.User;
+import com.zerobase.commerce.user.dto.form.SignUpForm;
+import com.zerobase.commerce.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public String signUp(SignUpForm form) {
+
+        if (userRepository.findByUserId(form.getUserId()).isPresent()) {
+            throw new RuntimeException("이미 존재하는 아이디입니다.");
+        }
+
+        if (!form.getPassword().equals(form.getCheckedPassword())) {
+            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String encPassword = BCrypt.hashpw(form.getPassword(), BCrypt.gensalt());
+        form.setPassword(encPassword);
+
+        User user = userRepository.save(SignUpForm.toEntity(form));
+
+        return "회원가입이 완료되었습니다.";
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+
+        Optional<User> optionalUser = userRepository.findByUserId(userId);
+        // 회원정보가 없는 경우
+        if (optionalUser.isEmpty()) {
+            throw new UsernameNotFoundException("회원 정보가 존재하지 않습니다.");
+        }
+        User user = optionalUser.get();
+
+        // role, 해당 회원의 역할, 해당 계정은 어느 권한까지 존재하는지, 단지 회원인지, 관리자인지 그걸 표현한 리스트가 UserDetails에 필요하다.
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority(Role.USER.name()));
+
+        // 관리자 권한이 있는 계정인 경우 추가
+
+        return new org.springframework.security.core.userdetails.User(user.getUserId(), user.getPassword(), grantedAuthorities);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
+# DEBUG COLOR
+spring.output.ansi.enabled=always
 
+# API REST KEY ??
+spring.profiles.include=db
+
+# log ?? ??
+#logging.level.root=DEBUG
+logging.level.root=INFO
+
+## Swagger ??
+#spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER

--- a/src/test/java/com/zerobase/commerce/configuration/TokenProviderTest.java
+++ b/src/test/java/com/zerobase/commerce/configuration/TokenProviderTest.java
@@ -1,0 +1,28 @@
+package com.zerobase.commerce.configuration;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TokenProviderTest {
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Test
+    void TokenParserTest() {
+        String token = tokenProvider.generateToken("zerobase157", "USER");
+
+        System.out.println(token);
+
+        Jws<Claims> parse = tokenProvider.parseToken(token);
+
+        System.out.println(parse.getHeader().toString());
+        System.out.println(parse.getBody().toString());
+        System.out.println(parse.getSignature().toString());
+    }
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- Spring Security 설정
- Jwt TokenProvider 구현
- 회원가입시에는 Spring Security BCrypt로 패스워드를 인코딩해서 저장, 로그인 및 그 외의 활동에 대해서는 JWT 토큰을 이용한 방식을 사용하려고 생각하고 있습니다.

**TO-BE**
- 스프링부트 버전이 높은걸 쓰다보니, Spring Security를 만지는데 난항을 겪고 있습니다. 
- 특히 페이지 구현 없이 API로만 진행할 생각인데, 
로그인 페이지 엔드포인트 설정(.loginpage("/user/login"))을 하니까 브라우저에서 http://localhost:8080/을 permitAll()을 해뒀는데도 무시하고 /user/login에서 무한루프가 돌아가는 이유를 공부해봐야합니다. 
로그인 페이지 엔드포인트 설정을 안하니까 브라우저에서 접속해볼 때 권한이 없다고 나오는 이유를 잘 모르겠습니다. 페이지 구현을 안해서 그렇다 쳐도 h2는 나와야하는거 아닌가..(("/**").permitAll()하면 나옴)
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] TokenProvider 테스트 코드
- [x] 회원가입 API 테스트 
